### PR TITLE
Fix stacktrace parsing edge case

### DIFF
--- a/utils/stacktrace.go
+++ b/utils/stacktrace.go
@@ -267,10 +267,10 @@ func parseStackTrace(stackTrace string) []string {
 			frames = append(frames, line)
 		}
 	}
-	if len(frames) > 1 {
-			return frames[2:]
-	}
-	return frames
+        if len(frames) > 2 {
+                        return frames[2:]
+        }
+        return frames
 }
 
 func PrettyPrintEdgeList(edgeList EdgeList) string {

--- a/utils/stacktrace_test.go
+++ b/utils/stacktrace_test.go
@@ -297,13 +297,14 @@ func BenchmarkStacktrace(b *testing.B) {
       name:               "Exactly Two Matching Frames",
       stackTrace:         "file1.go:100\nfile2.go:200",
       err:                fmt.Errorf("two frames only"),
-      // Two matching frames are discarded (frames[2:]) so effective frames = 0.
-      // Total edges = 4.
-      expectedEdgesCount:      4,
-      expectedEffectiveFrames: 0,
+      // Both frames should be included. Total edges = 4 base + 2 CONTAINS + 1 NEXT = 7.
+      expectedEdgesCount:      7,
+      expectedEffectiveFrames: 2,
       expectedReportError:     "two frames only",
       containsEdgeCheck: containsCheck{
-        shouldCheck: false,
+        shouldCheck:  true,
+        expectedFile: "file1.go",
+        expectedLine: 100,
       },
     },
     {


### PR DESCRIPTION
## Summary
- correctly handle stack traces that only contain two frames
- update benchmark/tests for the new expected behaviour

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684a8ff96efc8330899c679cf04e2d55