### PR TITLE
Fix typo in contribution docs

### DIFF
--- a/docs/Contribution.md
+++ b/docs/Contribution.md
@@ -4,7 +4,7 @@
 
 ### File naming convention
 
-- Golang files shold be named in snake case i.e (go_route.go)
+- Golang files should be named in snake case i.e (go_route.go)
 
 ## Frontend
 


### PR DESCRIPTION
## Summary
- fix typo in backend file naming convention

## Testing
- `go test ./...` *(fails: module download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684a910320008330a6964a64a4958799