### PR TITLE
Handle fractional seconds in ConvertTimeToTimestamp

### DIFF
--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -75,20 +75,28 @@ func GetInvoiceExpired(paymentRequest string) bool {
 }
 
 func ConvertTimeToTimestamp(date string) int {
-	format := "2006-01-02 15:04:05"
-	dateTouse := date
+	dateToUse := date
 
 	if strings.Contains(date, "+") {
 		dateSplit := strings.Split(date, "+")
-		dateTouse = strings.Trim(dateSplit[0], " ")
+		dateToUse = strings.Trim(dateSplit[0], " ")
 	}
 
-	t, err := time.Parse(format, dateTouse)
-	if err != nil {
-		logger.Log.Error("Parse string to timestamp: %v", err)
-	} else {
-		return int(t.Unix())
+	layouts := []string{
+		"2006-01-02 15:04:05.999999",
+		"2006-01-02 15:04:05",
 	}
+
+	var parseErr error
+	for _, layout := range layouts {
+		t, err := time.Parse(layout, dateToUse)
+		if err == nil {
+			return int(t.Unix())
+		}
+		parseErr = err
+	}
+
+	logger.Log.Error("Parse string to timestamp: %v", parseErr)
 	return 0
 }
 

--- a/utils/helpers_test.go
+++ b/utils/helpers_test.go
@@ -83,11 +83,15 @@ func TestConvertTimeToTimestamp(t *testing.T) {
 	dateWithPlus := "2024-10-16 09:21:21.743327+00"
 	dateWithoutPlus := "2024-10-16 09:21:21.743327"
 
+	expected, err := time.Parse("2006-01-02 15:04:05.999999", "2024-10-16 09:21:21.743327")
+	assert.NoError(t, err)
+	expectedTs := int(expected.Unix())
+
 	dateTimestamp1 := ConvertTimeToTimestamp(dateWithPlus)
 	dateTimestamp2 := ConvertTimeToTimestamp(dateWithoutPlus)
 
-	assert.Greater(t, dateTimestamp1, 7000000)
-	assert.Greater(t, dateTimestamp2, 7000000)
+	assert.Equal(t, expectedTs, dateTimestamp1)
+	assert.Equal(t, expectedTs, dateTimestamp2)
 }
 
 func TestGetHoursDifference(t *testing.T) {


### PR DESCRIPTION
## Summary
- support timestamps with fractional seconds and `+` timezone suffixes
- verify fractional second parsing in `TestConvertTimeToTimestamp`

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684a910458b88330a849100371cfa17c