### PR TITLE
Fix typo comments

### DIFF
--- a/websocket/client.go
+++ b/websocket/client.go
@@ -61,7 +61,7 @@ type TicketPlanDetails struct {
 
 func (c *Client) Read() {
 	defer func() {
-		// ceck to acoid nil pointer
+		// check to avoid nil pointer
 		if c.Pool != nil {
 			c.Pool.Unregister <- c
 			c.Conn.Close()

--- a/websocket/pool.go
+++ b/websocket/pool.go
@@ -26,7 +26,7 @@ func (pool *Pool) Start() {
 	for {
 		select {
 		case client := <-pool.Register:
-			// ceck to acoid nil pointer
+			// check to avoid nil pointer
 			if pool.Clients == nil {
 				pool.Clients = make(map[string]*ClientData)
 			}
@@ -49,7 +49,7 @@ func (pool *Pool) Start() {
 				fmt.Println("Websocket pool client save error")
 			}
 		case client := <-pool.Unregister:
-			// ceck to acoid nil pointer
+			// check to avoid nil pointer
 			if pool.Clients[client.Host] != nil {
 				pool.Clients[client.Host].Client.Conn.WriteJSON(Message{Type: 1, Body: "User Disconnected..."})
 				delete(pool.Clients, client.Host)
@@ -58,7 +58,7 @@ func (pool *Pool) Start() {
 
 		case message := <-pool.Broadcast:
 			fmt.Println("Sending message to all clients in Pool")
-			// ceck to acoid nil pointer
+			// check to avoid nil pointer
 			if pool.Clients != nil {
 				for client, _ := range pool.Clients {
 					if err := pool.Clients[client].Client.Conn.WriteJSON(message); err != nil {


### PR DESCRIPTION
## Summary
- fix typo in `websocket/client.go` and `websocket/pool.go`

## Testing
- `go test ./...` *(fails: Get https://proxy.golang.org/...: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684a9104d03083309b13fa68f5fc5bc4